### PR TITLE
feat: add addIntermediate method and macro to Logger

### DIFF
--- a/include/viennacore/vcChecks.hpp
+++ b/include/viennacore/vcChecks.hpp
@@ -85,7 +85,9 @@ inline const char *getCudaErrorString(CUresult result) {
   }
 
 #define CUDA_CHECK_NOEXCEPT(call)                                              \
-  { call; }
+  {                                                                            \
+    call;                                                                      \
+  }
 
 #define OPTIX_CHECK(call)                                                      \
   {                                                                            \

--- a/include/viennacore/vcLogger.hpp
+++ b/include/viennacore/vcLogger.hpp
@@ -174,7 +174,9 @@ public:
     if (getLogLevel() < 4)
       return *this;
 #pragma omp critical
-    { message += s + ": " + std::to_string(timeInSeconds) + " s \n"; }
+    {
+      message += s + ": " + std::to_string(timeInSeconds) + " s \n";
+    }
     return *this;
   }
 
@@ -192,12 +194,25 @@ public:
     return *this;
   }
 
+  // Add intermediate message if log level is high enough.
+  Logger &addIntermediate(const std::string &s) {
+    if (getLogLevel() < 3)
+      return *this;
+#pragma omp critical
+    {
+      message += s + "\n";
+    }
+    return *this;
+  }
+
   // Add info message if log level is high enough.
   Logger &addInfo(const std::string &s) {
     if (getLogLevel() < 2)
       return *this;
 #pragma omp critical
-    { message += s + "\n"; }
+    {
+      message += s + "\n";
+    }
     return *this;
   }
 
@@ -341,5 +356,12 @@ inline bool Logger::logToFile = false;
   do {                                                                         \
     if (viennacore::Logger::hasTiming()) {                                     \
       viennacore::Logger::getInstance().addTiming(msg, timer).print();         \
+    }                                                                          \
+  } while (0)
+
+#define VIENNACORE_LOG_INTERMEDIATE(msg)                                       \
+  do {                                                                         \
+    if (viennacore::Logger::hasIntermediate()) {                               \
+      viennacore::Logger::getInstance().addIntermediate(msg).print();          \
     }                                                                          \
   } while (0)

--- a/tests/logger/logger.cpp
+++ b/tests/logger/logger.cpp
@@ -27,6 +27,13 @@ int main() {
   VC_TEST_ASSERT(ss.str().find("    Timing message: 1.23") == 0);
   ss.str("");
 
+  logger.setLogLevel(LogLevel::INTERMEDIATE);
+  logger.addIntermediate("Intermediate message");
+  logger.print(ss);
+
+  VC_TEST_ASSERT(ss.str() == "    Intermediate message\n\033[0m");
+  ss.str("");
+
   logger.setLogLevel(LogLevel::INFO);
   logger.addInfo("Info message");
   logger.print(ss);


### PR DESCRIPTION
 The Logger defined LogLevel::INTERMEDIATE and hasIntermediate() but
 was missing the corresponding addIntermediate() add method and
 VIENNACORE_LOG_INTERMEDIATE macro. Adds both, following the addInfo pattern.
 
 style: reflow braces (clang-format touch-ups)